### PR TITLE
Refactor message entity and add validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -1,16 +1,27 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace RazorPagesTestSample.Data
+/// <summary>
+/// Represents a message entity with an ID and text content.
+/// </summary>
+namespace RazorPagesTestSample
 {
-    #region snippet1
     public class Message
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the message.
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text content of the message.
+        /// </summary>
+        /// <remarks>
+        /// The text content is required and must be a string with a maximum length of 250 characters.
+        /// </remarks>
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
-    #endregion
+
 }

--- a/src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
+++ b/src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.7.0" />

--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
-using RazorPagesTestSample.Data;
 using System.ComponentModel.DataAnnotations;
+using RazorPagesTestSample.Data;
 
 namespace RazorPagesTestSample.Tests.UnitTests
 {

--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using RazorPagesTestSample.Data;
+using System.ComponentModel.DataAnnotations;
 
 namespace RazorPagesTestSample.Tests.UnitTests
 {
@@ -25,7 +26,7 @@ namespace RazorPagesTestSample.Tests.UnitTests
                 // Assert
                 var actualMessages = Assert.IsAssignableFrom<List<Message>>(result);
                 Assert.Equal(
-                    expectedMessages.OrderBy(m => m.Id).Select(m => m.Text), 
+                    expectedMessages.OrderBy(m => m.Id).Select(m => m.Text),
                     actualMessages.OrderBy(m => m.Id).Select(m => m.Text));
             }
         }
@@ -77,7 +78,7 @@ namespace RazorPagesTestSample.Tests.UnitTests
                 await db.AddRangeAsync(seedMessages);
                 await db.SaveChangesAsync();
                 var recId = 1;
-                var expectedMessages = 
+                var expectedMessages =
                     seedMessages.Where(message => message.Id != recId).ToList();
                 #endregion
 
@@ -90,7 +91,7 @@ namespace RazorPagesTestSample.Tests.UnitTests
                 // Assert
                 var actualMessages = await db.Messages.AsNoTracking().ToListAsync();
                 Assert.Equal(
-                    expectedMessages.OrderBy(m => m.Id).Select(m => m.Text), 
+                    expectedMessages.OrderBy(m => m.Id).Select(m => m.Text),
                     actualMessages.OrderBy(m => m.Id).Select(m => m.Text));
                 #endregion
             }
@@ -121,10 +122,36 @@ namespace RazorPagesTestSample.Tests.UnitTests
                 // Assert
                 var actualMessages = await db.Messages.AsNoTracking().ToListAsync();
                 Assert.Equal(
-                    expectedMessages.OrderBy(m => m.Id).Select(m => m.Text), 
+                    expectedMessages.OrderBy(m => m.Id).Select(m => m.Text),
                     actualMessages.OrderBy(m => m.Id).Select(m => m.Text));
             }
         }
         #endregion
+
+
+        [Theory]
+        [InlineData(150, true)]
+        [InlineData(199, true)]
+        [InlineData(200, true)]
+        [InlineData(201, true)]
+        [InlineData(249, true)]
+        [InlineData(250, true)]
+        [InlineData(251, false)]
+        [InlineData(300, false)]
+        public async Task AddMessageAsync_TestMessageLength(int messageLength, bool expectedValidMessage)
+        {
+            using (var db = new AppDbContext(Utilities.TestDbContextOptions()))
+            {
+                // Arrange
+                var recId = 10;
+                var expectedMessage = new Message() { Id = recId, Text = new string('X', messageLength) };
+
+                // Act
+                var isValidMessage = Validator.TryValidateObject(expectedMessage, new ValidationContext(expectedMessage), null, validateAllProperties: true);
+
+                // Assert
+                Assert.Equal(expectedValidMessage, isValidMessage);
+            }
+        }
     }
 }

--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using RazorPagesTestSample.Pages;
 using RazorPagesTestSample.Data;
 
+
 namespace RazorPagesTestSample.Tests.UnitTests
 {
     public class IndexPageTests


### PR DESCRIPTION
- Refactored the Message class in RazorPagesTestSample.Data to RazorPagesTestSample.
- Added validation for the text content of the message, ensuring it is required and has a maximum length of 250 characters. Resolves #6